### PR TITLE
Fix indent of return from function

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -402,7 +402,7 @@ def CalculateBoilerSetPoint():
             TargetTemperature=Devices[MINBOILERTEMP].nValue
 
         #Return values
-            return True,TargetTemperature
+        return True,TargetTemperature
 
 def DomoticzAPI(APICall):
     resultJson = None


### PR DESCRIPTION
Found a bug in indentation of return from the function CalculateBoilerSetPoint()